### PR TITLE
Large file chunk support 

### DIFF
--- a/mrequests.py
+++ b/mrequests.py
@@ -180,10 +180,10 @@ class Response:
 
             if self.chunked:
 
-                t = self.read()
-                while len(t) > 0:
-                    fp.write(t)
-                    t = self.read()
+                chunk = self.read()
+                while len(chunk) > 0:
+                    fp.write(chunk)
+                    chunk = self.read()
 
             else:
                 while True:

--- a/mrequests.py
+++ b/mrequests.py
@@ -152,7 +152,7 @@ class Response:
 
                 if self._chunk_size == 0:
                     # End of message
-                    sep = sf.read(2)
+                    sep = self.sf.read(2)
                     if sep != b"\r\n":
                         raise ValueError("Expected final chunk separator, read %r instead." % sep)
 

--- a/mrequests.py
+++ b/mrequests.py
@@ -177,19 +177,28 @@ class Response:
         read = 0
 
         with open(fn, "wb") as fp:
-            while True:
-                remain = self._content_size - read
 
-                if remain <= 0:
-                    break
+            if self.chunked:
 
-                chunk = self.read(min(chunk_size, remain))
-                read += len(chunk)
+                t = self.read()
+                while len(t) > 0:
+                    fp.write(t)
+                    t = self.read()
 
-                if not chunk:
-                    break
+            else:
+                while True:
+                    remain = self._content_size - read
 
-                fp.write(chunk)
+                    if remain <= 0:
+                        break
+
+                    chunk = self.read(min(chunk_size, remain))
+                    read += len(chunk)
+
+                    if not chunk:
+                        break
+
+                    fp.write(chunk)
 
         self.close()
 


### PR DESCRIPTION
When a server sets the header to include 'Transfer-encoding: chunked' it also OMITS the 'Content-length: <value>' from the header. That means default _content_length remains 0. Then the save() function always creates the file and then exits...since 'remain = self._content_size - read' will always result in a value of 0.

The response parser was correctly detecting the 'Transfer-encoding: chunked' and setting the necessary flags so I added detection for that condition and just read the stream into the file until the chunk read returns nothing from the stream.

I have tested the change extensively within my own project that is using mrequests but am not sure how to add such testing to this repository. The external server has the responsibility of setting the transfer encoding value.  Please advise.