### PR TITLE
Mpremote install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.mpy
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ An HTTP client module for MicroPython with an API *similar* to [requests].
 This is an evolution of the [urequests] module from [micropython-lib] with a few
 extensions and many fixes and convenience features.
 
+
 ## Features & Limitations
+
 
 ### Compatibility
 
@@ -17,6 +19,7 @@ due to problems with MicroPython's `ssl` module on these platforms.
 
 On the stm32 port installing a custom-compiled firmware with network/SSL
 support is required.
+
 
 ### Features
 
@@ -30,6 +33,7 @@ support is required.
   a file, reading the response data and writing the file in small chunks.
 * The `Response` class for response objects can be substituted by a custom
   response class.
+
 
 ### Limitations
 
@@ -61,6 +65,7 @@ support is required.
 * In responses using "chunked" transfer-encoding, chunk extensions and trailers
   are ignored.
 
+
 ### Redirection Support
 
 * Can follow redirects for response status codes 301, 302, 303, 307 and 308.
@@ -78,12 +83,14 @@ support is required.
 * The code does not check for infinite redirection cycles. It is advised to
   keep `max_redirects` to a low number instead.
 
+
 ## Installation
 
 While there are multiple ways to install the library from your PC's command line, two installation methods are provided through shell scripts
 
 * **mpremote**
 * **rshell** (legacy)
+
 
 ### mpremote
 
@@ -95,6 +102,7 @@ The following should be installed and in your shell's `PATH`:
 Run the command
 
     ./install_mpremote.sh
+
 
 ### rshell
 
@@ -126,9 +134,11 @@ provide support for sending form-encoded request parameters or data (see the
 `formencode.py` script in the `examples` directory for an example of their
 use).
 
+
 ## Examples
 
 See the scripts in the [examples](./examples) directory for more.
+
 
 ### Simple GET request with JSON response
 
@@ -165,6 +175,7 @@ It is mandatory to close response objects as soon as you finished working with
 them. On MicroPython platforms without full-fledged OS, not doing so may lead
 to resource leaks and malfunction.
 
+
 ### HTTP Basic Auth
 
 ```py
@@ -180,6 +191,7 @@ to resource leaks and malfunction.
 }
 >>> r.close()
 ```
+
 
 ## Reference
 
@@ -284,11 +296,13 @@ delete(url, **kw)
 
 The url and all keyword arguments are simply passed to `request`.
 
+
 ## Authors
 
 **mrequests** is based on [urequests], written by *Paul Sokolovsky* and
 part of [micropython-lib] and licensed under the [MIT license]. It was further
 developed and is maintained by *Christopher Arndt*.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ An HTTP client module for MicroPython with an API *similar* to [requests].
 This is an evolution of the [urequests] module from [micropython-lib] with a few
 extensions and many fixes and convenience features.
 
-
 ## Features & Limitations
-
 
 ### Compatibility
 
@@ -19,7 +17,6 @@ due to problems with MicroPython's `ssl` module on these platforms.
 
 On the stm32 port installing a custom-compiled firmware with network/SSL
 support is required.
-
 
 ### Features
 
@@ -34,37 +31,35 @@ support is required.
 * The `Response` class for response objects can be substituted by a custom
   response class.
 
-
 ### Limitations
 
-- `mrequests.request` is a synchroneous, blocking function.
-- The code is *not* interrupt save and a fair amount of memory allocation is
+* `mrequests.request` is a synchroneous, blocking function.
+* The code is *not* interrupt save and a fair amount of memory allocation is
   happening in the process of handling a request.
-- URL parsing does not cover all corner cases (see [test_urlparse] for details).
-- URLs with authentication credentials in the host part (e.g.
+* URL parsing does not cover all corner cases (see [test_urlparse] for details).
+* URLs with authentication credentials in the host part (e.g.
   `http://user:secret@myhost/`) are *not supported*. Pass authentication
   credentials separately via the `auth` argument instead.
-- SSL/TLS support on the MicroPython *unix*, *stm32* and *esp8266* ports is
+* SSL/TLS support on the MicroPython *unix*, *stm32* and *esp8266* ports is
   limited. In particular, their `ssl` module does not support all encryption
   schemes commonly in use by popular servers, meaning that trying to connect
   to them via HTTPS will fail with various cryptic error messages.
-- Request and JSON data may be passed in as bytes or strings and the request
+* Request and JSON data may be passed in as bytes or strings and the request
   data will be encoded to bytes, if necessary, using the encoding given with
   the `encoding` parameter. But be aware that encodings other than `utf-8` are
   *not supported* by most (any?) MicroPython implementations.
-- Custom headers may be passed as a dictionary with string or bytes keys and
+* Custom headers may be passed as a dictionary with string or bytes keys and
   values and must contain only ASCII chars. If you need header values to use
   non-ASCII chars, you need to encode them according to RFC 8187.
-- The URL and specifically any query string parameters it contains will not be
+* The URL and specifically any query string parameters it contains will not be
   URL-encoded, and it may contain only ASCII chars. Make sure you encode the
   query string part of the URL with `urlencode.quote` before passing it, if
   necessary.
-- When encoding `str` instances via `urlencode.urlencode` or `urlencode.quote`,
+* When encoding `str` instances via `urlencode.urlencode` or `urlencode.quote`,
   the `encoding` and `errors` arguments are currently ignored by MicroPython and
   it behaves as if their values were `"utf-8"` resp. `"ignore"`.
-- In responses using "chunked" transfer-encoding, chunk extensions and trailers
+* In responses using "chunked" transfer-encoding, chunk extensions and trailers
   are ignored.
-
 
 ### Redirection Support
 
@@ -83,11 +78,23 @@ support is required.
 * The code does not check for infinite redirection cycles. It is advised to
   keep `max_redirects` to a low number instead.
 
-
 ## Installation
 
-Make sure you have `mpy-cross` and `rshell` installed and in your shell's
-`PATH`.
+### mpremote
+
+The following should be installed and in your shell's `PATH`:
+
+* `mpy-cross`
+* `mpremote`
+
+    ./install_mpremote.sh
+
+### rshell
+
+The following should be installed and in your shell's `PATH`:
+
+* `mpy-cross`
+* `rshell`
 
 For boards with the `stm32` port:
 
@@ -111,7 +118,6 @@ and can be installed and used on its own. `defaultdict.py` and `urlencode.py`
 provide support for sending form-encoded request parameters or data (see the
 `formencode.py` script in the `examples` directory for an example of their
 use).
-
 
 ## Examples
 
@@ -152,7 +158,6 @@ It is mandatory to close response objects as soon as you finished working with
 them. On MicroPython platforms without full-fledged OS, not doing so may lead
 to resource leaks and malfunction.
 
-
 ### HTTP Basic Auth
 
 ```py
@@ -168,7 +173,6 @@ to resource leaks and malfunction.
 }
 >>> r.close()
 ```
-
 
 ## Reference
 
@@ -273,13 +277,11 @@ delete(url, **kw)
 
 The url and all keyword arguments are simply passed to `request`.
 
-
 ## Authors
 
 **mrequests** is based on [urequests], written by *Paul Sokolovsky* and
 part of [micropython-lib] and licensed under the [MIT license]. It was further
 developed and is maintained by *Christopher Arndt*.
-
 
 ## License
 
@@ -287,7 +289,6 @@ developed and is maintained by *Christopher Arndt*.
 and Open Source software.
 
 Please see the file [LICENSE](./LICENSE) for details.
-
 
 [micropython-lib]: https://github.com/micropython/micropython-lib
 [mit license]: http://opensource.org/licenses/MIT

--- a/README.md
+++ b/README.md
@@ -80,12 +80,19 @@ support is required.
 
 ## Installation
 
+While there are multiple ways to install the library from your PC's command line, two installation methods are provided through shell scripts
+
+* **mpremote**
+* **rshell** (legacy)
+
 ### mpremote
 
 The following should be installed and in your shell's `PATH`:
 
 * `mpy-cross`
 * `mpremote`
+
+Run the command
 
     ./install_mpremote.sh
 

--- a/install.sh
+++ b/install.sh
@@ -10,5 +10,5 @@ for py in ${MODULES[*]}; do
     ${RSHELL:-rshell} --quiet \
         -b ${BAUD:-9600} \
         -p ${PORT:-/dev/ttyACM0} \
-        cp "${py%.*}".mpy "${DESTDIR:-/pyboard}"
+        cp "${py%.*}".mpy "${DESTDIR:-/pyboard/lib}"
 done

--- a/install_mpremote.sh
+++ b/install_mpremote.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Install mrequests to a MicroPython board
+
+MODULES=('defaultdict.py' 'mrequests.py' 'urlencode.py' 'urlparseqs.py' 'urlunquote.py')
+DESTDIR=":/lib/"
+for py in ${MODULES[*]}; do
+    echo "Compiling $py to ${py%.*}.mpy"
+    mpy-cross "$py"
+    mpremote cp ${py%.*}.mpy "${DESTDIR}${py%.*}.mpy" 
+done

--- a/install_mpremote.sh
+++ b/install_mpremote.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 #
-# Install mrequests to a MicroPython board
+# Install mrequests to a MicroPython board using mpremote
 
 MODULES=('defaultdict.py' 'mrequests.py' 'urlencode.py' 'urlparseqs.py' 'urlunquote.py')
-DESTDIR=":/lib/"
+DESTDIR=":/lib"
+
+# Create the root lib folder
+# Will generate an error in the output if it already exists
+# 
+# Traceback (most recent call last):
+#   File "<stdin>", line 2, in <module>
+# OSError: [Errno 17] EEXIST
+mpremote mkdir "${DESTDIR}"
+
 for py in ${MODULES[*]}; do
     echo "Compiling $py to ${py%.*}.mpy"
     mpy-cross "$py"
-    mpremote cp ${py%.*}.mpy "${DESTDIR}${py%.*}.mpy" 
+    mpremote cp ${py%.*}.mpy "${DESTDIR}/${py%.*}.mpy" 
 done


### PR DESCRIPTION
Added an additional `install_mpremote.sh` and instructions in order to preserve the legacy of `rshell`, which some users may prefer, but `mpremote` should be the default way to install until `mip` (and `mpremote mip`) support is added via means of `package.json` and proper folder structure.

I also threw in a `.gitignore` mostly for the stupid Mac OS **.DS_Store** files littering our systems 🥲 

Open to feedback and change requests for this PR 


