### PR TITLE
fix: make sure 'remain' is defined

### DIFF
--- a/mrequests/mrequests.py
+++ b/mrequests/mrequests.py
@@ -198,6 +198,8 @@ class Response:
                 raise NotImplementedError("Cannot set chunk_size when using a buffer with CPython."
                     " Use a buffer or memoryview of appropriate size instead.")
 
+        remain = self._content_size
+
         while True:
             if buf:
                 num_read_chunk = self.readinto(buf, chunk_size)


### PR DESCRIPTION
I just noticed that "remain" isn't correctly set in all cases. Here's a tiny fix for it.